### PR TITLE
Use current db name when selecting redash DB size

### DIFF
--- a/redash/monitor.py
+++ b/redash/monitor.py
@@ -48,7 +48,7 @@ def get_db_sizes():
     database_metrics = []
     queries = [
         ['Query Results Size', "select pg_total_relation_size('query_results') as size from (select 1) as a"],
-        ['Redash DB Size', "select pg_database_size('postgres') as size"]
+        ['Redash DB Size', "select pg_database_size(current_database()) as size"]
     ]
     for query_name, query in queries:
         result = models.db.session.execute(query).first()


### PR DESCRIPTION
Not all of the databases that Redash runs on are called `postgres` :)

This uses the postgresql function `current_database` to determine db size instead of a hard-coded name.

This is currently crashing our system status page because our db name (running on Heroku) is not 'postgres'.